### PR TITLE
Fix for rubocop-rspec 0.20.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -107,3 +107,6 @@ RSpec/MessageSpies:
 
 RSpec/NestedGroups:
   Max: 5
+
+RSpec/ContextWording:
+    Enabled: false

--- a/daru-io.gemspec
+++ b/daru-io.gemspec
@@ -33,5 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'yard'
+
   spec.add_development_dependency 'guard-rspec' if RUBY_VERSION >= '2.2.5'
 end


### PR DESCRIPTION
Before #68, fixes against rubocop-rspec 0.20.1 needs to be merged.