### PR TITLE
Compability with Ruby 2.5.x and Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - '2.2'
   - '2.3.0'
   - '2.4.0'
+  - '2.5.0'
 
 script:
   - bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :optional do
-  gem 'activerecord', '~> 4.0'
+  gem 'activerecord', '>= 4.0'
   gem 'avro'
   gem 'dbd-sqlite3'
   gem 'dbi'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :optional do
   gem 'avro'
   gem 'dbd-sqlite3'
   gem 'dbi'
-  gem 'jsonpath'
+  gem 'jsonpath', '>= 0.9.6'
   gem 'mongo'
   gem 'nokogiri'
   gem 'redis'

--- a/lib/daru/io/base.rb
+++ b/lib/daru/io/base.rb
@@ -23,7 +23,7 @@ module Daru
       #   #=> true
       #
       # @example Requires with version and requires
-      #   optional_gem 'activerecord', '~> 4.0', requires: 'active_record'
+      #   optional_gem 'activerecord', '>= 4.0', requires: 'active_record'
       #   #=> true
       #
       # @example Raises error with meaningful message

--- a/lib/daru/io/importers/active_record.rb
+++ b/lib/daru/io/importers/active_record.rb
@@ -10,7 +10,7 @@ module Daru
 
         # Checks for required gem dependencies of ActiveRecord Importer
         def initialize
-          optional_gem 'activerecord', '~> 4.0', requires: 'active_record'
+          optional_gem 'activerecord', '>= 4.0', requires: 'active_record'
         end
 
         # Loads data from a given relation

--- a/lib/daru/io/importers/sql.rb
+++ b/lib/daru/io/importers/sql.rb
@@ -11,7 +11,7 @@ module Daru
         # Checks for required gem dependencies of SQL Importer
         def initialize
           optional_gem 'dbd-sqlite3', requires: 'dbd/SQLite3'
-          optional_gem 'activerecord', '~> 4.0', requires: 'active_record'
+          optional_gem 'activerecord', '>= 4.0', requires: 'active_record'
           optional_gem 'dbi'
           optional_gem 'sqlite3'
         end


### PR DESCRIPTION
Hi SciRuby-Community / daru-io maintainers 👋

I wanted to experiment with `daru-io` in a Rails-5/Ruby 2.5.x environment and noticed it won't work out-of-the-box. So I decided trying to upgrade/ope the dependencies so that it will.

On my way to make it work I stumbled over a problem of [jsonpath with Ruby 2.5.1](https://github.com/joshbuddy/jsonpath/issues/98) because of some failing tests. Luckily the bug has been quickly fixed by the jsonpath maintainers shortly after I reported it. That's why I added the lower version boundary for `jsonpath` here.

Since this is my first PR to the project I hope the PR is on par with your style ad guidelines. If not, I'd be happy for som feedback.  