### PR TITLE
daru dependency as >= 0.2.0, change version to 0.1.1

### DIFF
--- a/daru-io.gemspec
+++ b/daru-io.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'daru', '~> 0.2.0'
+  spec.add_development_dependency 'daru', '>= 0.2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/daru/io/version.rb
+++ b/lib/daru/io/version.rb
@@ -1,5 +1,5 @@
 module Daru
   module IO
-    VERSION = '0.1.0'.freeze
+    VERSION = '0.1.1'.freeze
   end
 end


### PR DESCRIPTION
In response to https://github.com/SciRuby/daru-io/issues/78#issuecomment-466979801 , making this PR.

In my second thought, I thought it would be better if we lower bound the dependency version, instead of using `~>` constraint.

Reason is that since the release frequency of Daru and Daru-io seems to be different, using `~>` constraint makes it cumbersome to manage the dependency in of this project.  Instead, I thought it would be better if we simply just use the lower bound.

Any opinion?